### PR TITLE
i13: make ring safer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ring
 Title: Circular / Ring Buffers
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com")
 Description: Circular / ring buffers in R and C.  There are a couple
@@ -16,5 +16,5 @@ Suggests:
     knitr,
     rmarkdown,
     testthat
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ring 1.0.1
+
+* Several small safety tweaks preventing crashes ([#13](https://github.com/richfitz/ring/issues/13))
+
 # ring 1.0.0 (2017-04-24)
 
 * Initial CRAN release

--- a/inst/include/ring/ring.c
+++ b/inst/include/ring/ring.c
@@ -42,13 +42,16 @@ ring_buffer * ring_buffer_create(size_t size, size_t stride,
 }
 
 void ring_buffer_destroy(ring_buffer *buffer) {
+  if (buffer) {
 #ifdef RING_USE_STDLIB_ALLOC
-  free(buffer->data);
-  free(buffer);
+    free(buffer->data);
+    free(buffer);
 #else
-  Free(buffer->data);
-  Free(buffer);
+    Free(buffer->data);
+    Free(buffer);
 #endif
+    buffer = NULL;
+  }
 }
 
 ring_buffer * ring_buffer_duplicate(const ring_buffer *buffer) {

--- a/inst/include/ring/ring.c
+++ b/inst/include/ring/ring.c
@@ -449,7 +449,7 @@ const void * ring_buffer_search_linear(const ring_buffer *buffer,
 const void * ring_buffer_search_bisect(const ring_buffer *buffer, size_t i,
                                        ring_predicate *pred, void *data) {
   const size_t n = ring_buffer_used(buffer, false);
-  if (n == 0) {
+  if (n == 0 || i >= n) {
     return NULL;
   }
   int i0 = i, i1 = i;
@@ -459,7 +459,7 @@ const void * ring_buffer_search_bisect(const ring_buffer *buffer, size_t i,
   // Predicate should return true if we should look further back
   // (increase the tail offset), false otherwise.
   if (pred((void*) x0, data)) { // advance up until we hit the top
-    if (i0 == (int)n - 1) { // guess is already *at* the top.
+    if (i0 >= (int)n - 1) { // guess is already *at* the top.
       return x0;
     }
     i1 = i0 + 1;

--- a/man/ring_buffer_bytes.Rd
+++ b/man/ring_buffer_bytes.Rd
@@ -462,6 +462,7 @@ the differences between implementations will be a bit more apparent.
 }
 }
 }
+
 \examples{
 # Create a ring buffer of 100 bytes
 b <- ring_buffer_bytes(100)
@@ -515,4 +516,3 @@ b$read(b$used())
 b$push(as.raw(1:75))
 b$read(b$used())
 }
-

--- a/man/ring_buffer_bytes_translate.Rd
+++ b/man/ring_buffer_bytes_translate.Rd
@@ -451,6 +451,7 @@ the differences between implementations will be a bit more apparent.
 }
 }
 }
+
 \examples{
 # The "typed" ring buffers do not allow for character vectors to
 # be stored, because strings are generally hard and have unknown
@@ -516,4 +517,3 @@ try(
 \author{
 Rich FitzJohn
 }
-

--- a/man/ring_buffer_bytes_typed.Rd
+++ b/man/ring_buffer_bytes_typed.Rd
@@ -444,6 +444,7 @@ the differences between implementations will be a bit more apparent.
 }
 }
 }
+
 \examples{
 # Create a ring buffer of 30 integers:
 b <- ring_buffer_bytes_typed(30, integer(1))
@@ -493,4 +494,3 @@ b$tail_offset(1)
 \author{
 Rich FitzJohn
 }
-

--- a/man/ring_buffer_env.Rd
+++ b/man/ring_buffer_env.Rd
@@ -444,6 +444,7 @@ the differences between implementations will be a bit more apparent.
 }
 }
 }
+
 \examples{
 buf <- ring_buffer_env(10)
 buf$push(1:10)
@@ -486,4 +487,3 @@ tryCatch(buf$push(100),
 \author{
 Rich FitzJohn
 }
-

--- a/tests/testthat/test-search.R
+++ b/tests/testthat/test-search.R
@@ -131,3 +131,18 @@ test_that("nontrivial, wrapped", {
     }
   }
 })
+
+
+test_that("search from too far along", {
+  set.seed(10)
+  b <- ring_buffer_bytes_typed(10, double(1))
+  b$push(rep(1, 6))
+  b$take(6)
+  x <- sort(runif(8))
+  b$push(x)
+
+  z <- mean(x)
+
+  expect_equal(test_search(b$.ptr, z, "bisect", length(x)), -1)
+  expect_equal(test_search(b$.ptr, z, "bisect", length(x) * 2), -1)
+})


### PR DESCRIPTION
This eliminates a couple of crashes seen while dealing with the odin rewrite and debugging the malaria model (see https://github.com/mrc-ide/dde/pull/15).

* The simplest way of dealing with allocating and freeing in odin turns out to be null first, then free, then allocate because that works equally well for both constant and user defined data.  But ring is not safe for a double free
* dde (before https://github.com/mrc-ide/dde/pull/15) was proposing reading outside the range of values held in the ring - this should not crash the R session