### PR TITLE
CRAN fixes

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -15,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -23,28 +24,39 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ src/*.gcno
 src/*.gcda
 src/*.gcov
 docs/
+*.o
+*.so
+*.dll

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: Circular / ring buffers in R and C.  There are a couple
     of different buffers here with different implementations that
     represent different trade-offs.
 License: MIT + file LICENSE
-URL: https://mrc-ide.gitub.io/ring, https://github.com/mrc-ide/ring
+URL: https://mrc-ide.github.io/ring/, https://github.com/mrc-ide/ring
 BugReports: https://github.com/mrc-ide/ring/issues
 Imports:
     R6

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ring
 Title: Circular / Ring Buffers
-Version: 1.0.7
+Version: 1.0.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- badges: start -->
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R-CMD-check](https://github.com/mrc-ide/ring/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/mrc-ide/ring/actions/workflows/R-CMD-check.yaml)
-[![codecov.io](https://codecov.io/github/mrc-ide/ring/coverage.svg?branch=master)](https://app.codecov.io/github/mrc-ide/ring?branch=master)
+[![Codecov test coverage](https://codecov.io/gh/mrc-ide/ring/graph/badge.svg)](https://app.codecov.io/gh/mrc-ide/ring)
 <!-- badges: end -->
 
 > Ring buffers in R and C

--- a/src/convert.c
+++ b/src/convert.c
@@ -14,7 +14,9 @@ SEXP bytes_to_logical(SEXP x) {
   size_t len = LENGTH(x);
   size_t n = len / sizeof(int);
   SEXP ret = PROTECT(Rf_allocVector(LGLSXP, n));
-  memcpy(INTEGER(ret), data, len);
+  if (n > 0) {
+    memcpy(INTEGER(ret), data, len);
+  }
   UNPROTECT(1);
   return ret;
 }
@@ -33,7 +35,9 @@ SEXP bytes_to_int(SEXP x) {
   size_t len = LENGTH(x);
   size_t n = len / sizeof(int);
   SEXP ret = PROTECT(Rf_allocVector(INTSXP, n));
-  memcpy(INTEGER(ret), data, len);
+  if (n > 0) {
+    memcpy(INTEGER(ret), data, len);
+  }
   UNPROTECT(1);
   return ret;
 }
@@ -52,7 +56,9 @@ SEXP bytes_to_double(SEXP x) {
   size_t len = LENGTH(x);
   size_t n = len / sizeof(double);
   SEXP ret = PROTECT(Rf_allocVector(REALSXP, n));
-  memcpy(REAL(ret), data, len);
+  if (n > 0) {
+    memcpy(REAL(ret), data, len);
+  }
   UNPROTECT(1);
   return ret;
 }
@@ -71,7 +77,9 @@ SEXP bytes_to_complex(SEXP x) {
   size_t len = LENGTH(x);
   size_t n = len / sizeof(Rcomplex);
   SEXP ret = PROTECT(Rf_allocVector(CPLXSXP, n));
-  memcpy(COMPLEX(ret), data, len);
+  if (n > 0) {
+    memcpy(COMPLEX(ret), data, len);
+  }
   UNPROTECT(1);
   return ret;
 }

--- a/src/convert.c
+++ b/src/convert.c
@@ -4,7 +4,9 @@ SEXP logical_to_bytes(SEXP x) {
   int * data = INTEGER(x);
   size_t len = LENGTH(x) * sizeof(int);
   SEXP ret = PROTECT(Rf_allocVector(RAWSXP, len));
-  memcpy(RAW(ret), data, len);
+  if (len > 0) {
+    memcpy(RAW(ret), data, len);
+  }
   UNPROTECT(1);
   return ret;
 }
@@ -25,7 +27,9 @@ SEXP int_to_bytes(SEXP x) {
   int * data = INTEGER(x);
   size_t len = LENGTH(x) * sizeof(int);
   SEXP ret = PROTECT(Rf_allocVector(RAWSXP, len));
-  memcpy(RAW(ret), data, len);
+  if (len > 0) {
+    memcpy(RAW(ret), data, len);
+  }
   UNPROTECT(1);
   return ret;
 }
@@ -46,7 +50,9 @@ SEXP double_to_bytes(SEXP x) {
   double * data = REAL(x);
   size_t len = LENGTH(x) * sizeof(double);
   SEXP ret = PROTECT(Rf_allocVector(RAWSXP, len));
-  memcpy(RAW(ret), data, len);
+  if (len > 0) {
+    memcpy(RAW(ret), data, len);
+  }
   UNPROTECT(1);
   return ret;
 }
@@ -67,7 +73,9 @@ SEXP complex_to_bytes(SEXP x) {
   Rcomplex * data = COMPLEX(x);
   size_t len = LENGTH(x) * sizeof(Rcomplex);
   SEXP ret = PROTECT(Rf_allocVector(RAWSXP, len));
-  memcpy(RAW(ret), data, len);
+  if (len > 0) {
+    memcpy(RAW(ret), data, len);
+  }
   UNPROTECT(1);
   return ret;
 }


### PR DESCRIPTION
See 

* CRAN testthat logs https://www.stats.ox.ac.uk/pub/bdr/M1-SAN/ring/tests/testthat.Rout
* rhub replication of these logs https://github.com/mrc-ide/ring/actions/runs/20112481569/job/57713288964 (unfold line 294)
* The hint as to the problem in the CRAN notes: https://www.stats.ox.ac.uk/pub/bdr/M1-SAN/README.txt
* The fixed build on rhub https://github.com/mrc-ide/ring/actions/runs/20112744526/job/57714247885

As you can see in the implementation the fix is simple (9d50b57). The problem is (I think) that it looks like we're going to write into `int*` via `memcpy` but in the case where the destination vector has size 0 the value of `INTEGER(ret)` is an address that would be misaligned for the write. The write doesn't happen of course but depending on that is probably also depending on UB

In the end (0f22d84) I just decided to be as simple as possible, give all `memcpy` calls the same treatment, as it made the file a bit weird to look at otherwise.

Clean build on R-devel via win builder: https://win-builder.r-project.org/Mb7qI2450s11/

Drive by fix on a url (#22 -- one line, one missed bug in review) and update the coverage action and .gitignore

I'm happy to yolo this in @weshinsley , but you might also be interested...